### PR TITLE
fix: asg resource does not automatically add the default_tags from the AWS provider

### DIFF
--- a/_data.tf
+++ b/_data.tf
@@ -15,3 +15,5 @@ data "aws_subnet" "subnets" {
 }
 
 data "aws_region" "current" {}
+
+data "aws_default_tags" "current" {}

--- a/asg.tf
+++ b/asg.tf
@@ -1,3 +1,10 @@
+locals {
+  all_tags = merge(
+    data.aws_default_tags.current.tags,
+    var.tags
+  )
+}
+
 resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
   name_prefix               = "asg-${var.bastion_name}"
   max_size                  = var.bastion_instance_count
@@ -23,7 +30,7 @@ resource "aws_autoscaling_group" "bastion_auto_scaling_group" {
   }
 
   dynamic "tag" {
-    for_each = var.tags
+    for_each = local.all_tags
 
     content {
       key                 = tag.key


### PR DESCRIPTION
The Auto Scaling Group does not automatically inherit the `default_tags` from the AWS provider. The `default_tags` work for most AWS resources, but the Auto Scaling Group has a special behavior—it requires tags to be explicitly defined using individual tag blocks.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the CONTRIBUTING.md doc.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...